### PR TITLE
remove keypath for decode(:)

### DIFF
--- a/Sources/CodableKit/AnyCodingKey+Keypath.swift
+++ b/Sources/CodableKit/AnyCodingKey+Keypath.swift
@@ -31,33 +31,6 @@ extension KeyedDecodingContainerProtocol where Key == AnyCodingKey {
     }
 }
 
-extension KeyedEncodingContainerProtocol where Key == AnyCodingKey {
-    
-    /// Encodes the given value for the given keyPath
-    ///
-    ///  e.g. `try container.encode(value1, forKeyPath: "b0.b1.value")`
-    ///
-    /// - Parameters:
-    ///   - value: the value to encode
-    ///   - keyPath: The keypath to associate the value with.
-    /// - Throws: same as encode<T>(_ value:forKey:)
-    ///
-    public mutating func encode<T: Encodable>(_ value: T, forKeyPath keyPath: Self.Key) throws {
-    
-        let paths = keyPath.keyPaths()
-        if paths.count <= 1 {
-            try self.encode(value, forKey: keyPath)
-            return
-        }
-        
-        let pathKeys = Array(paths[0..<paths.count-1])
-        let nameKey = paths.last!
-        var container = self.nestedContainer(for: pathKeys)
-        try container.encode(value, forKey: nameKey)
-    }
-}
-
-
 extension KeyedDecodingContainerProtocol where Key == AnyCodingKey {
     
     public func nestedContainer(forKey key: Key, useKeyPath: Bool = true) throws -> KeyedDecodingContainer<AnyCodingKey> {

--- a/Tests/CodableKitTests/AnyCodingKey_Keypath_Tests.swift
+++ b/Tests/CodableKitTests/AnyCodingKey_Keypath_Tests.swift
@@ -13,12 +13,14 @@ class AnyCodingKey_Keypath_Tests: XCTestCase {
     func test_keyPath_decoding() {
         struct Model: Decodable {
             let a: Int
+            let dot: Int
             let value1: Int
             let value2: [Int]
             
             init(from decoder: Decoder) throws {
                 let container = try decoder.container()
                 a = try container.decode("a")
+                dot = try container.decode("a.key.contain.dot", useKeyPath: false)
                 value1 = try container.decode("b0.b1.value")
                 value2 = try container.decode("c0.c1")
             }
@@ -26,6 +28,7 @@ class AnyCodingKey_Keypath_Tests: XCTestCase {
         let data = """
             {
                 "a": 1,
+                "a.key.contain.dot": 2,
                 "b0": {
                     "b1": {
                         "value" : 233
@@ -39,6 +42,7 @@ class AnyCodingKey_Keypath_Tests: XCTestCase {
         do {
             let m = try JSONDecoder().decode(Model.self, from: data)
             XCTAssertEqual(m.a, 1)
+            XCTAssertEqual(m.dot, 2)
             XCTAssertEqual(m.value1, 233)
             XCTAssertEqual(m.value2, [1,2])
         } catch let e {
@@ -49,21 +53,36 @@ class AnyCodingKey_Keypath_Tests: XCTestCase {
     func test_keyPath_Encoding() {
         struct Model: Encodable {
             let a: Int
+            let dot: Int
             let value1: Int
-            let value2: [Int]
+            let value2: String
+            let c1: [Int]
             
             func encode(to encoder: Encoder) throws {
                 var container = encoder.container()
-                try container.encode(a, forKeyPath: "a")
-                try container.encode(value1, forKeyPath: "b0.b1.value")
-                try container.encode(value2, forKeyPath: "c0.c1")
+                
+                var deeper = container.nestedContainer(forKey: "b0.b1")
+                try deeper.encode(value1, forKey: "value1")
+                try deeper.encode(value2, forKey: "value2")
+                
+                var another = container.nestedContainer(forKey: "c0")
+                try another.encode(c1, forKey: "c1")
+                
+                try container.encode(a, forKey: "a")
+
+                var another2 = container.nestedContainer(forKey: "a.key.contain.dot", useKeyPath: false)
+                try another2.encode(dot, forKey: "dot")
             }
         }
         let rawDict: NSDictionary = [
             "a": 1,
+            "a.key.contain.dot": [
+                "dot": 2
+            ],
             "b0": [
                 "b1": [
-                    "value" : 233
+                    "value1" : 233,
+                    "value2": "hi"
                 ]
             ],
             "c0": [
@@ -71,7 +90,7 @@ class AnyCodingKey_Keypath_Tests: XCTestCase {
             ]
         ]
         do {
-            let data = try JSONEncoder().encode(Model(a: 1, value1: 233, value2: [1,2]))
+            let data = try JSONEncoder().encode(Model(a: 1, dot:2, value1: 233, value2: "hi", c1:[1,2]))
             let dict = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as! NSDictionary
             XCTAssertEqual(dict, rawDict)
         } catch let e {


### PR DESCRIPTION
The implementation is wrong, so I delete the API